### PR TITLE
Add test for PopupAlert + OpenObjectButton

### DIFF
--- a/ListSelectOpenObjectTest/form.json
+++ b/ListSelectOpenObjectTest/form.json
@@ -1,0 +1,69 @@
+{
+    "actions": [
+        {
+            "caption": "List of Events",
+            "type": "List",
+            "name": "Events",
+            "add": false,
+            "delete": false,
+            "sort": {
+                "column": "Topic",
+                "direction": "ascending"
+            },
+            "columns": [
+                {
+                    "caption": "Topic",
+                    "name": "Topic",
+                    "width": "auto"
+                },
+                {
+                    "caption": "Open Instance",
+                    "name": "OpenEventReceiversInstance",
+                    "visible": false,
+                    "edit": {
+                        "type": "OpenObjectButton",
+                        "name": "OpenInstanceButton",
+                        "enabled": false
+                    },
+                    "objectID": 0
+                },
+                {
+                    "caption": "Events are used by this instances:",
+                    "name": "Receivers",
+                    "visible": false,
+                    "edit": {
+                        "type": "List",
+                        "name": "EventReceiver",
+                        "add": false,
+                        "delete": false,
+                        "sort": {
+                            "column": "instanceID",
+                            "direction": "ascending"
+                        },
+                        "columns": [
+                            {
+                                "caption": "Instance",
+                                "name": "instanceID",
+                                "width": "90px",
+                                "onClick": "IPS_RequestAction($id, 'UpdateOpenObjectButton', $Receivers['instanceID']);"
+                            },
+                            {
+                                "caption": "Type",
+                                "name": "Type",
+                                "width": "150px",
+                                "onClick": "IPS_RequestAction($id, 'UpdateOpenObjectButton', $Receivers['instanceID']);"
+                            },
+                            {
+                                "caption": "Name",
+                                "name": "Name",
+                                "width": "auto",
+                                "onClick": "IPS_RequestAction($id, 'UpdateOpenObjectButton', $Receivers['instanceID']);"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "values": []
+        }
+    ]
+}

--- a/ListSelectOpenObjectTest/module.json
+++ b/ListSelectOpenObjectTest/module.json
@@ -1,0 +1,13 @@
+{
+	"id": "{FF001225-12BB-41A4-BD5F-C46A12404ABB}",
+	"name": "ListSelectOpenObjectTest",
+	"type": 3,
+	"vendor": "",
+	"aliases": [
+		"ListSelectInstance OpenObjectButton Test"
+	],
+	"parentRequirements": [],
+	"childRequirements": [],
+	"implemented": [],
+	"prefix": "LOT"
+}

--- a/ListSelectOpenObjectTest/module.php
+++ b/ListSelectOpenObjectTest/module.php
@@ -1,0 +1,47 @@
+<?php
+
+    class ListSelectOpenObjectTest extends IPSModule
+    {
+        public function RequestAction($Ident, $Value)
+        {
+            if ($Ident == 'UpdateOpenObjectButton') {
+                $this->UpdateFormField('OpenEventReceiversInstance', 'objectID', $Value);
+                $this->UpdateFormField('OpenEventReceiversInstance', 'enabled', true);
+                $this->UpdateFormField('OpenEventReceiversInstance', 'caption', sprintf('Open instance (%d): %s', $Value, IPS_GetName($Value)));
+                return;
+            }
+        }
+
+        public function GetConfigurationForm()
+        {
+            $Form = json_decode(file_get_contents(__DIR__ . '/form.json'), true);
+            $EventList = $this->GetEventReceiverFormValues();
+            $Form['actions'][0]['values'] = $EventList;
+            return json_encode($Form);
+        }
+
+        protected function GetEventReceiverFormValues()
+        {
+            $EventList = [];
+            $Instances = IPS_GetInstanceList();
+            shuffle($Instances);
+            $i=0;
+            $Receivers = [];
+            do {
+                $Receiver = array_shift($Instances);
+                $Receivers[] = [
+                    'instanceID' => $Receiver,
+                    'Name'       => IPS_GetName($Receiver),
+                    'Type'       => substr(IPS_GetInstance($Receiver)['ModuleInfo']['ModuleName'], 6)
+                ];
+                $i++;
+            } while (count($Instances) && $i<5);
+               
+            $EventList[] = [
+                    'Topic'      => 'bla bla Topic',
+                    'Receivers'  => $Receivers
+                ];
+            
+            return $EventList;
+        }
+    }

--- a/PopupAlertTest/form.json
+++ b/PopupAlertTest/form.json
@@ -1,0 +1,23 @@
+{
+    "actions": [
+        {
+            "type": "PopupAlert",
+            "name": "ErrorPopup",
+            "visible": true,
+            "popup": {
+                "buttons": [
+                    {
+                        "caption": "No, stop it!",
+                        "onClick": "PAT_Stop($id);"
+                    }
+                ],
+                "items": [
+                    {
+                        "type": "Label",
+                        "caption": "Some errors occur.....in 10 seconds.\r\nPlease press OK and switch to another Tab!"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/PopupAlertTest/module.json
+++ b/PopupAlertTest/module.json
@@ -1,0 +1,13 @@
+{
+	"id": "{F66F1A1C-5CCE-4B89-A0BE-F2ADF267891B}",
+	"name": "PopupAlertTest",
+	"type": 3,
+	"vendor": "",
+	"aliases": [
+		"PopupAlert Test"
+	],
+	"parentRequirements": [],
+	"childRequirements": [],
+	"implemented": [],
+	"prefix": "PAT"
+}

--- a/PopupAlertTest/module.php
+++ b/PopupAlertTest/module.php
@@ -1,0 +1,28 @@
+<?php
+
+    class PopupAlertTest extends IPSModule
+    {
+        public function Create()
+        {
+            parent::Create();
+            
+            $this->RegisterTimer('UpdateError', 0, 'PAT_Update(' . $this->InstanceID . ');');
+        }
+        
+        public function Update()
+        {
+            $this->UpdateFormField('ErrorPopup', 'visible', true);
+        }
+
+        public function Stop()
+        {
+            $this->SetTimerInterval('UpdateError', 0);
+        }
+
+        public function GetConfigurationForm()
+        {
+            $this->SetTimerInterval('UpdateError', 10*1000);
+            $Form = json_decode(file_get_contents(__DIR__ . '/form.json'), true);
+            return json_encode($Form);
+        }
+    }


### PR DESCRIPTION
PopupAlertTest:
Die Instanz öffnet alle 10 Sekunden ein PopupAlert, welches auch angezeigt wird, wenn der Tab keinen Focus hat.
Das Popup sollte aber nur in den Vordergrund kommen, wenn der Tab auch aktiv ist.

ListSelectOpenObjectTest:
Innerhalb einer Liste wird ein weitere Liste mit Instanzen angezeigt.
Nach dem auswählen einer Zeil wird der OpenObjectButton aktiv um direkt zu der ausgewählten Instanz zu springen.
Gewünschtes Verhalten ist das Öffnen der Instanz.
Allerdings erfolgt das nicht und es gibt eine Fehlermeldung der Konsole.